### PR TITLE
FilterForCompatible: fixes driver being excluded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/jacobweinstock/registrar
 
-go 1.15
+go 1.17
 
 require (
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.6
 )
+
+require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect

--- a/registrar.go
+++ b/registrar.go
@@ -118,7 +118,7 @@ func (r Registry) FilterForCompatible(ctx context.Context) Drivers {
 	wg.Wait()
 
 	var result Drivers
-	for i := 0; i < len(state); i++ {
+	for i := 0; i <= len(state); i++ {
 		if state[i] != nil {
 			result = append(result, state[i])
 		}

--- a/registrar.go
+++ b/registrar.go
@@ -93,7 +93,7 @@ func (r Registry) GetDriverInterfaces() []interface{} {
 func (r Registry) FilterForCompatible(ctx context.Context) Drivers {
 	var wg sync.WaitGroup
 	mutex := &sync.Mutex{}
-	state := make(map[int]*Driver)
+	state := make([]*Driver, len(r.Drivers))
 
 	for index, elem := range r.Drivers {
 		index := index
@@ -118,10 +118,12 @@ func (r Registry) FilterForCompatible(ctx context.Context) Drivers {
 	wg.Wait()
 
 	var result Drivers
-	for i := 0; i <= len(state); i++ {
-		if state[i] != nil {
-			result = append(result, state[i])
+	for i := 0; i < len(state); i++ {
+		if state[i] == nil {
+			continue
 		}
+
+		result = append(result, state[i])
 	}
 
 	return result


### PR DESCRIPTION
Since the loop was counting up until less than `len(state)`
this meant that drivers that are compatible but second in list would be
excluded from the returned results.